### PR TITLE
"Incorrect password." bug when trying to authenticate with simple password

### DIFF
--- a/game/ticketServer/index.php
+++ b/game/ticketServer/index.php
@@ -34,11 +34,6 @@ global $enableYubikey, $passwordHashingPepper;
 
 <body onload="calcHMAC()">
 
-<FORM>
-    <INPUT TYPE="password" MAXLENGTH=20 SIZE=20 NAME="password" autofocus id="hmacInputText" onkeyup="calcHMAC()">
-</FORM>
-
-
 
 <FORM ACTION="server.php" METHOD="post">
 <?php
@@ -50,11 +45,15 @@ if( $enableYubikey ) {
     <INPUT TYPE="password" MAXLENGTH=48 SIZE=48 NAME="yubikey">
 
 <?php
+    } else {
+?>
+    <INPUT TYPE="password" MAXLENGTH=20 SIZE=20 NAME="password" autofocus id="hmacInputText" onkeyup="calcHMAC()">
+<?php
     }
 ?>
 
     <INPUT TYPE="hidden" NAME="action" VALUE="show_data">
-	        <INPUT TYPE="Submit" VALUE="login">
+    <INPUT TYPE="Submit" VALUE="login">
 
 <br>
 <br>

--- a/game/ticketServer/server.php
+++ b/game/ticketServer/server.php
@@ -3230,14 +3230,14 @@ function ts_checkPassword( $inFunctionName ) {
 
     $passwordSent = false;
     
-    if( isset( $_REQUEST[ "passwordHMAC" ] ) ) {
+    if( isset( $_REQUEST[ "password" ] ) ) {
         $passwordSent = true;
 
         // already hashed client-side on login form
         // hash again, because hash client sends us is not stored in
         // our settings file
         $password = ts_hmac_sha1( $passwordHashingPepper,
-                                  $_REQUEST[ "passwordHMAC" ] );
+                                  $_REQUEST[ "password" ] );
         
         
         // generate a new hash cookie from this password


### PR DESCRIPTION
I tried to authenticate with a simple password as described here: https://thecastledoctrine.gamepedia.com/Setting_up_a_Server and the server kept saying "Incorrect password." It seems it was sending the hashed one and rehashing it at the server.

Now it sends it in clear (at least it works) but depends on a HTTPS.
I leave it here for anyone who needs it.

I suspect the idea is to do a double hashing, one in the client and one in the server, but since the former tutorial says nothing about...