### PR TITLE
stdcall__ is required for winapi calls

### DIFF
--- a/game/platforms/SDL/gameSDL.cpp
+++ b/game/platforms/SDL/gameSDL.cpp
@@ -1429,7 +1429,7 @@ int mainFunction( int inNumArgs, char **inArgs ) {
             PROCESS_PER_MONITOR_DPI_AWARE  = 2
             } PROCESS_DPI_AWARENESS;
         
-        typedef HRESULT (*SetProcessDpiAwarenessFunc)( PROCESS_DPI_AWARENESS );
+        typedef HRESULT (__stdcall *SetProcessDpiAwarenessFunc)( PROCESS_DPI_AWARENESS );
         
         SetProcessDpiAwarenessFunc setAwareness = 
             (SetProcessDpiAwarenessFunc)GetProcAddress(
@@ -1462,7 +1462,7 @@ int mainFunction( int inNumArgs, char **inArgs ) {
         
         if( hUser32 != NULL ) {
             
-            typedef BOOL (*SetProcessDPIAwareFunc)();
+            typedef BOOL (__stdcall *SetProcessDPIAwareFunc)();
             
             SetProcessDPIAwareFunc setDPIAware = 
                 (SetProcessDPIAwareFunc)GetProcAddress( hUser32, 


### PR DESCRIPTION
observed effect: incorrect calling convention could result in
incorrect esp stack pointer, causing the value of the native
resolution parameter to screengl to get overwritten during
call setup.