### PR TITLE
Fixed memory leak on Linux when toggling fullscreen.

### DIFF
--- a/graphics/openGL/SingleTextureGL.cpp
+++ b/graphics/openGL/SingleTextureGL.cpp
@@ -69,16 +69,6 @@ void SingleTextureGL::disableTexturing() {
 void SingleTextureGL::reloadFromBackup() {
     
     if( mBackupBytes != NULL ) {
-        
-        glGenTextures( 1, &mTextureID );
-        
-        int error = glGetError();
-        if( error != GL_NO_ERROR ) {		// error
-            printf( "Error generating new texture ID, error = %d, \"%s\"\n",
-                    error, glGetString( error ) );
-            }
-        
-        
         setTextureData( mBackupBytes, mAlphaOnly, 
                         mWidthBackup, mHeightBackup, 
                         // backup already has edges expanded


### PR DESCRIPTION
copying form: https://github.com/twohoursonelife/minorGems/pull/11 as I want you to also look into this problem and give your opinion on the fix and if you find it right you can merge it, Thank you Jason!

when player toggles in or out from full-screen mode with Alt+Enter key, all game textures are recreated but the old ones are not deleted from memory. on my Linux machine this caused the game to eat +1GB each time i toggle in and out of full-screen mode and in one instance before I knew about this problem caused the whole system to crash due to low memory.

in this fix I removed the creation of new Texture and instead directly update the old textures data.

Another possible fix for this would be to delete the old texture with `glDeleteTextures` before creating a new texture with `glGenTextures` like this
```cpp
void SingleTextureGL::reloadFromBackup() {
    
    if( mBackupBytes != NULL ) {

        glDeleteTextures(1, &mTextureID); // <++++++++++++++
        glGenTextures(1, &mTextureID);

        int error = glGetError();
        if (error != GL_NO_ERROR) {
            printf("Error generating new texture ID, error = %d, \"%s\"\n",
                   error, glGetString(error));
        }
        setTextureData( mBackupBytes, mAlphaOnly, 
                        mWidthBackup, mHeightBackup, 
                        false );
    }
}
```
but I removed the generation of new texture completely and allowed `setTextureData` to replace the old texture data directly.


picture of game using 10GB of memory after multiple switching between full-screen and windowed to use other programs.
![image](https://github.com/twohoursonelife/minorGems/assets/37766821/c8d61089-29c0-442a-8f29-8922ebd73783)
I don't know why this does not happen on windows, but I suspect it's because windows and linux have different OpenGL implementations or different graphics driver implementations for each operating system.